### PR TITLE
Fix that specifies correct url endpoints based on regions.

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
+++ b/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
@@ -272,12 +272,20 @@ public class S3Method {
                 url.append("https://");
                 if( temporaryEndpoint == null ) {
                     boolean validDomainName = isValidDomainName(bucket);
+                    String regionId = provider.getContext().getRegionId();
+
                     if( bucket != null && validDomainName ) {
                         url.append(bucket);
-                        url.append(".s3.amazonaws.com/");
+                        if (regionId != null && !"us-east-1".equals(regionId)) {
+                            url.append(".s3-");
+                            url.append(regionId);
+                            url.append(".amazonaws.com/");
+                        }
+                        else {
+                            url.append(".s3.amazonaws.com/");
+                        }
                     }
                     else if ( bucket != null && !validDomainName) {
-                        String regionId = provider.getContext().getRegionId();
 
                         if (regionId != null && !"us-east-1".equals(regionId)) {
                             url.append("s3-");


### PR DESCRIPTION
We were having issues while creating a bucket in AWS for all regions except for "us-east-1".
The fix was tested in dev and it specifies the correct url endpoints for all regions.
