### PR TITLE
Fix that specifies the correct url endpoints based on regions.

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
+++ b/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
@@ -273,14 +273,22 @@ public class S3Method {
 
             if( provider.getEC2Provider().isAWS() ) {
                 url.append("https://");
+                String regionId = provider.getContext().getRegionId();
+
                 if( temporaryEndpoint == null ) {
                     boolean validDomainName = isValidDomainName(bucket);
                     if( bucket != null && validDomainName ) {
                         url.append(bucket);
-                        url.append(".s3.amazonaws.com/");
+                        if (regionId != null && !"us-east-1".equals(regionId)) {
+                            url.append(".s3-");
+                            url.append(regionId);
+                            url.append(".amazonaws.com/");
+                        }
+                        else {
+                            url.append(".s3.amazonaws.com/");
+                        }
                     }
                     else if ( bucket != null && !validDomainName) {
-                        String regionId = provider.getContext().getRegionId();
 
                         if (regionId != null && !"us-east-1".equals(regionId)) {
                             url.append("s3-");


### PR DESCRIPTION
We were having issues while creating a bucket in AWS for all regions except for "us-east-1".
The fix was tested in dev and it specifies the correct url endpoints for all regions.
