### PR TITLE
Fix issues with filtering incorrect value keys

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/network/VPC.java
+++ b/src/main/java/org/dasein/cloud/aws/network/VPC.java
@@ -1423,7 +1423,7 @@ public class VPC extends AbstractVLANSupport {
             Document doc;
 
             parameters.put("Filter.1.Name", "attachment.instance-id");
-            parameters.put("Filter.2.Value.1", forVmId);
+            parameters.put("Filter.1.Value.1", forVmId);
             method = new EC2Method(provider, provider.getEc2Url(), parameters);
             try {
                 doc = method.invoke();
@@ -1466,7 +1466,7 @@ public class VPC extends AbstractVLANSupport {
             Document doc;
 
             parameters.put("Filter.1.Name", "subnet-id");
-            parameters.put("Filter.2.Value.1", subnetId);
+            parameters.put("Filter.1.Value.1", subnetId);
             method = new EC2Method(provider, provider.getEc2Url(), parameters);
             try {
                 doc = method.invoke();
@@ -1509,7 +1509,7 @@ public class VPC extends AbstractVLANSupport {
             Document doc;
 
             parameters.put("Filter.1.Name", "vpc-id");
-            parameters.put("Filter.2.Value.1", vlanId);
+            parameters.put("Filter.1.Value.1", vlanId);
             method = new EC2Method(provider, provider.getEc2Url(), parameters);
             try {
                 doc = method.invoke();


### PR DESCRIPTION
Some of the filtering done in the VPC network support was using incorrect keys for the filter value. This resulted in an EC2Method exception stating that the value cannot be null. 
