### PR TITLE
Include the EBS volumes in the VirtualMachine object.

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/compute/EC2Instance.java
+++ b/src/main/java/org/dasein/cloud/aws/compute/EC2Instance.java
@@ -633,11 +633,13 @@ public class EC2Instance extends AbstractVMSupport<AWSCloud> {
             if( endTimestamp < 1L ) {
                 endTimestamp = System.currentTimeMillis() + 1000L;
             }
-            if( startTimestamp > (endTimestamp - (2L * CalendarWrapper.MINUTE)) ) {
+            if( startTimestamp < (System.currentTimeMillis() - (2L * CalendarWrapper.DAY)) ) {
+               startTimestamp = System.currentTimeMillis() - (2L * CalendarWrapper.DAY);
+               if( startTimestamp > (endTimestamp - (2L * CalendarWrapper.MINUTE)) ) {
+                  endTimestamp = startTimestamp + (2L * CalendarWrapper.MINUTE);
+              }
+            } else if( startTimestamp > (endTimestamp - (2L * CalendarWrapper.MINUTE)) ) {
                 startTimestamp = endTimestamp - (2L * CalendarWrapper.MINUTE);
-            }
-            else if( startTimestamp < (System.currentTimeMillis() - (2L * CalendarWrapper.DAY)) ) {
-                startTimestamp = System.currentTimeMillis() - (2L * CalendarWrapper.DAY);
             }
 
             calculateCpuUtilization(statistics, instanceId, startTimestamp, endTimestamp);
@@ -661,11 +663,13 @@ public class EC2Instance extends AbstractVMSupport<AWSCloud> {
             if( endTimestamp < 1L ) {
                 endTimestamp = System.currentTimeMillis() + 1000L;
             }
-            if( startTimestamp > (endTimestamp - (2L * CalendarWrapper.MINUTE)) ) {
+            if( startTimestamp < (System.currentTimeMillis() - CalendarWrapper.DAY) ) {
+               startTimestamp = System.currentTimeMillis() - CalendarWrapper.DAY;
+               if( startTimestamp > (endTimestamp - (2L * CalendarWrapper.MINUTE)) ) {
+                  endTimestamp = startTimestamp + (2L * CalendarWrapper.MINUTE);
+              }
+            } else if( startTimestamp > (endTimestamp - (2L * CalendarWrapper.MINUTE)) ) {
                 startTimestamp = endTimestamp - (2L * CalendarWrapper.MINUTE);
-            }
-            else if( startTimestamp < (System.currentTimeMillis() - CalendarWrapper.DAY) ) {
-                startTimestamp = System.currentTimeMillis() - CalendarWrapper.DAY;
             }
             TreeMap<Integer,VmStatistics> statMap = new TreeMap<Integer,VmStatistics>();
             int minutes = (int)((endTimestamp-startTimestamp)/CalendarWrapper.MINUTE);


### PR DESCRIPTION
When AWS returns information about a VM instance, it includes the ids of the volumes attached to the instance if the instance is using EBS. It would be nice if the VirtualMachine class provided that information; having it there is a lot easier than having to query all of the volumes and then scan the volumes to determine which ones are attached to the instance in question.

This is part 2 of the patch for dasein-cloud-aws issue #87.
