### PR TITLE
Gather EBS metrics when instance uses EBS storage

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/compute/EC2Instance.java
+++ b/src/main/java/org/dasein/cloud/aws/compute/EC2Instance.java
@@ -2038,7 +2038,6 @@ public class EC2Instance extends AbstractVMSupport<AWSCloud> {
           server.setProviderFirewallIds( firewalls.toArray(new String[firewalls.size()]) );
         }
       }
-      // BEGIN Unisys changes
       else if ( name.equals( "blockDeviceMapping" ) ) {
          ArrayList<String> volumes = new ArrayList<String>();
          if ( attr.hasChildNodes() ) {
@@ -2074,7 +2073,6 @@ public class EC2Instance extends AbstractVMSupport<AWSCloud> {
            server.setProviderVolumeIds( volumes.toArray(new String[volumes.size()]) );
          }
        }
-       // END Unisys changes
     }
       if( server.getPlatform() == null ) {
 		    server.setPlatform(Platform.UNKNOWN);
@@ -2159,7 +2157,7 @@ public class EC2Instance extends AbstractVMSupport<AWSCloud> {
                 prd.setCpuCount(1);
             }
             if( json.has("rootVolumeSizeInGb") ) {
-                prd.setRootVolumeSize(new Storage<Gigabyte>(json.getInt("rootVolumeSizeInGb"), Storage.GIGABYTE));
+                prd.setRootVolumeSize(new Storage<Gigabyte>(json.getDouble("rootVolumeSizeInGb"), Storage.GIGABYTE));
             }
             else {
                 prd.setRootVolumeSize(new Storage<Gigabyte>(1, Storage.GIGABYTE));


### PR DESCRIPTION
The current getStatistics() methods return disk metrics only if the VM instance uses instance storage. The proposed patch extends the statics method to capture either VM instance disk statistics or EBS volume statistics depending on what the VM is configured to use. 
