### PR TITLE
Force HTTP connection closure after each request

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/compute/EC2Method.java
+++ b/src/main/java/org/dasein/cloud/aws/compute/EC2Method.java
@@ -43,6 +43,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
@@ -633,13 +634,14 @@ public class EC2Method {
             wire.debug("");
             wire.debug("--------------------------------------------------------------------------------------");
         }
+        HttpClient client = null;
 	    try {
     		if( logger.isDebugEnabled() ) {
     			logger.debug("Talking to server at " + url);
     		}
 
             HttpPost post = new HttpPost(url);
-            HttpClient client = getClient();
+            client = getClient();
 
             HttpResponse response;
 
@@ -884,6 +886,9 @@ public class EC2Method {
             }
 	    }
 	    finally {
+            if (client != null) {
+                client.getConnectionManager().shutdown();
+            }
 	        if( logger.isTraceEnabled() ) {
 	            logger.trace("EXIT - " + EC2Method.class.getName() + ".invoke()");
 	        }

--- a/src/main/java/org/dasein/cloud/aws/network/Route53Method.java
+++ b/src/main/java/org/dasein/cloud/aws/network/Route53Method.java
@@ -224,8 +224,9 @@ public class Route53Method {
 		if( logger.isDebugEnabled() ) {
 			logger.debug("Talking to server at " + url);
 		}
+        HttpClient client = null;
 		try {
-    		HttpClient client = getClient();
+            client = getClient();
             HttpResponse response;
     		int status;
     
@@ -413,6 +414,9 @@ public class Route53Method {
     		}
         }
         finally {
+            if (client != null) {
+                client.getConnectionManager().shutdown();
+            }
             logger.debug("Done");
         }
 	}

--- a/src/main/java/org/dasein/cloud/aws/platform/CloudFrontMethod.java
+++ b/src/main/java/org/dasein/cloud/aws/platform/CloudFrontMethod.java
@@ -198,142 +198,148 @@ public class CloudFrontMethod {
         int status;
 
         try {
-            APITrace.trace(provider, action.toString());
-            httpResponse = client.execute(method);
-            status = httpResponse.getStatusLine().getStatusCode();
-
-        }
-        catch( IOException e ) {
-            logger.error(e);
-            e.printStackTrace();
-            throw new InternalException(e);
-        }
-        Header header = httpResponse.getFirstHeader("ETag");
-
-        if( header != null ) {
-            response.etag = header.getValue();
-        }
-        else {
-            response.etag = null;
-        }
-        if( status == HttpServletResponse.SC_OK || status == HttpServletResponse.SC_CREATED || status == HttpServletResponse.SC_ACCEPTED ) {
             try {
-                HttpEntity entity = httpResponse.getEntity();
+                APITrace.trace(provider, action.toString());
+                httpResponse = client.execute(method);
+                status = httpResponse.getStatusLine().getStatusCode();
 
-                if( entity == null ) {
-                    throw new CloudFrontException(status, null, null, "NoResponse", "No response body was specified");
-                }
-                InputStream input;
-
-                try {
-                    input = entity.getContent();
-                }
-                catch( IOException e ) {
-                    throw new CloudException(e);
-                }
-                try {
-                    response.document = parseResponse(input);
-                    return response;
-                }
-                finally {
-                    input.close();
-                }
             }
             catch( IOException e ) {
                 logger.error(e);
                 e.printStackTrace();
-                throw new CloudException(e);
+                throw new InternalException(e);
             }
-        }
-        else if( status == HttpServletResponse.SC_NO_CONTENT ) {
-            return null;
-        }
-        else {
-            if( status == HttpServletResponse.SC_SERVICE_UNAVAILABLE || status == HttpServletResponse.SC_INTERNAL_SERVER_ERROR ) {
-                if( attempts >= 5 ) {
-                    String msg;
+            Header header = httpResponse.getFirstHeader("ETag");
 
-                    if( status == HttpServletResponse.SC_SERVICE_UNAVAILABLE ) {
-                        msg = "Cloud service is currently unavailable.";
+            if( header != null ) {
+                response.etag = header.getValue();
+            }
+            else {
+                response.etag = null;
+            }
+            if( status == HttpServletResponse.SC_OK || status == HttpServletResponse.SC_CREATED || status == HttpServletResponse.SC_ACCEPTED ) {
+                try {
+                    HttpEntity entity = httpResponse.getEntity();
+
+                    if( entity == null ) {
+                        throw new CloudFrontException(status, null, null, "NoResponse", "No response body was specified");
+                    }
+                    InputStream input;
+
+                    try {
+                        input = entity.getContent();
+                    }
+                    catch( IOException e ) {
+                        throw new CloudException(e);
+                    }
+                    try {
+                        response.document = parseResponse(input);
+                        return response;
+                    }
+                    finally {
+                        input.close();
+                    }
+                }
+                catch( IOException e ) {
+                    logger.error(e);
+                    e.printStackTrace();
+                    throw new CloudException(e);
+                }
+            }
+            else if( status == HttpServletResponse.SC_NO_CONTENT ) {
+                return null;
+            }
+            else {
+                if( status == HttpServletResponse.SC_SERVICE_UNAVAILABLE || status == HttpServletResponse.SC_INTERNAL_SERVER_ERROR ) {
+                    if( attempts >= 5 ) {
+                        String msg;
+
+                        if( status == HttpServletResponse.SC_SERVICE_UNAVAILABLE ) {
+                            msg = "Cloud service is currently unavailable.";
+                        }
+                        else {
+                            msg = "The cloud service encountered a server error while processing your request.";
+                        }
+                        logger.error(msg);
+                        throw new CloudException(msg);
                     }
                     else {
-                        msg = "The cloud service encountered a server error while processing your request.";
+                        try { Thread.sleep(5000L); }
+                        catch( InterruptedException ignore ) { }
+                        return invoke(args);
                     }
-                    logger.error(msg);
-                    throw new CloudException(msg);
                 }
-                else {
-                    try { Thread.sleep(5000L); }
-                    catch( InterruptedException ignore ) { }
-                    return invoke(args);
-                }
-            }
-            try {
-                HttpEntity entity = httpResponse.getEntity();
-
-                if( entity == null ) {
-                    throw new CloudFrontException(status, null, null, "NoResponse", "No response body was specified");
-                }
-                InputStream input;
-
                 try {
-                    input = entity.getContent();
+                    HttpEntity entity = httpResponse.getEntity();
+
+                    if( entity == null ) {
+                        throw new CloudFrontException(status, null, null, "NoResponse", "No response body was specified");
+                    }
+                    InputStream input;
+
+                    try {
+                        input = entity.getContent();
+                    }
+                    catch( IOException e ) {
+                        throw new CloudException(e);
+                    }
+                    Document doc;
+
+                    try {
+                        doc = parseResponse(input);
+                    }
+                    finally {
+                        input.close();
+                    }
+                    if( doc != null ) {
+                        String code = null, message = null, requestId = null, type = null;
+                        NodeList blocks = doc.getElementsByTagName("Error");
+
+                        if( blocks.getLength() > 0 ) {
+                            Node error = blocks.item(0);
+                            NodeList attrs;
+
+                            attrs = error.getChildNodes();
+                            for( int i=0; i<attrs.getLength(); i++ ) {
+                                Node attr = attrs.item(i);
+
+                                if( attr.getNodeName().equals("Code") ) {
+                                    code = attr.getFirstChild().getNodeValue().trim();
+                                }
+                                else if( attr.getNodeName().equals("Type") ) {
+                                    type = attr.getFirstChild().getNodeValue().trim();
+                                }
+                                else if( attr.getNodeName().equals("Message") ) {
+                                    message = attr.getFirstChild().getNodeValue().trim();
+                                }
+                            }
+
+                        }
+                        blocks = doc.getElementsByTagName("RequestId");
+                        if( blocks.getLength() > 0 ) {
+                            Node id = blocks.item(0);
+
+                            requestId = id.getFirstChild().getNodeValue().trim();
+                        }
+                        if( message == null ) {
+                            throw new CloudException("Unable to identify error condition: " + status + "/" + requestId + "/" + code);
+                        }
+                        throw new CloudFrontException(status, requestId, type, code, message);
+                    }
+                    throw new CloudException("Unable to parse error.");
                 }
                 catch( IOException e ) {
+                    logger.error(e);
+                    e.printStackTrace();
                     throw new CloudException(e);
                 }
-                Document doc;
-
-                try {
-                    doc = parseResponse(input);
-                }
-                finally {
-                    input.close();
-                }
-                if( doc != null ) {
-                    String code = null, message = null, requestId = null, type = null;
-                    NodeList blocks = doc.getElementsByTagName("Error");
-
-                    if( blocks.getLength() > 0 ) {
-                        Node error = blocks.item(0);
-                        NodeList attrs;
-
-                        attrs = error.getChildNodes();
-                        for( int i=0; i<attrs.getLength(); i++ ) {
-                            Node attr = attrs.item(i);
-
-                            if( attr.getNodeName().equals("Code") ) {
-                                code = attr.getFirstChild().getNodeValue().trim();
-                            }
-                            else if( attr.getNodeName().equals("Type") ) {
-                                type = attr.getFirstChild().getNodeValue().trim();
-                            }
-                            else if( attr.getNodeName().equals("Message") ) {
-                                message = attr.getFirstChild().getNodeValue().trim();
-                            }
-                        }
-
-                    }
-                    blocks = doc.getElementsByTagName("RequestId");
-                    if( blocks.getLength() > 0 ) {
-                        Node id = blocks.item(0);
-
-                        requestId = id.getFirstChild().getNodeValue().trim();
-                    }
-                    if( message == null ) {
-                        throw new CloudException("Unable to identify error condition: " + status + "/" + requestId + "/" + code);
-                    }
-                    throw new CloudFrontException(status, requestId, type, code, message);
-                }
-                throw new CloudException("Unable to parse error.");
             }
-            catch( IOException e ) {
-                logger.error(e);
-                e.printStackTrace();
-                throw new CloudException(e);
+        } finally {
+            if (client != null) {
+                client.getConnectionManager().shutdown();
             }
         }
-	}
+    }
 	
 	private Document parseResponse(InputStream responseBodyAsStream) throws CloudException, InternalException {
 		try {

--- a/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
+++ b/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
@@ -267,11 +267,11 @@ public class S3Method {
             wire.debug("");
             wire.debug("----------------------------------------------------------------------------------");
         }
+        HttpClient client = null;
         try {
             StringBuilder url = new StringBuilder();
             boolean leaveOpen = false;
             HttpRequestBase method;
-            HttpClient client;
             int status;
 
             // Sanitise the parameters as they may have spaces and who knows what else
@@ -668,6 +668,9 @@ public class S3Method {
             throw new InternalException(e);
         }
         finally {
+            if (client != null) {
+                client.getConnectionManager().shutdown();
+            }
             if( wire.isDebugEnabled() ) {
                 wire.debug("----------------------------------------------------------------------------------");
                 wire.debug("");


### PR DESCRIPTION
This patch attempts to close HttpClient connections after they are no longer used. Otherwise the connections linger in `CLOSE_WAIT` until the associated objects are garbage-collected. This may not be the best approach, but does work.
