### PR TITLE
Don't close S3 connections with a stream response

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
+++ b/src/main/java/org/dasein/cloud/aws/storage/S3Method.java
@@ -268,9 +268,9 @@ public class S3Method {
             wire.debug("----------------------------------------------------------------------------------");
         }
         HttpClient client = null;
+        boolean leaveOpen = false;
         try {
             StringBuilder url = new StringBuilder();
-            boolean leaveOpen = false;
             HttpRequestBase method;
             int status;
 
@@ -668,7 +668,7 @@ public class S3Method {
             throw new InternalException(e);
         }
         finally {
-            if (client != null) {
+            if (!leaveOpen && client != null) {
                 client.getConnectionManager().shutdown();
             }
             if( wire.isDebugEnabled() ) {


### PR DESCRIPTION
I was overzealous in 2fb90e1ff4240d1 with closing connections and killed the S3 connection while a response still needed to be read. This should fix it. Verified by @rwfaulkner
