### PR TITLE
Pull the VPCId from the DescribeLoadBalancer response

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/network/ElasticLoadBalancer.java
+++ b/src/main/java/org/dasein/cloud/aws/network/ElasticLoadBalancer.java
@@ -1491,6 +1491,7 @@ public class ElasticLoadBalancer extends AbstractLoadBalancerSupport<AWSCloud> {
         long created = 0L;
         LbType type = null;
         ArrayList<String> subnetList = new ArrayList<String>();
+        String vlanId = null;
 
         if( regionId == null ) {
             throw new CloudException("No region was set for this context");
@@ -1578,6 +1579,9 @@ public class ElasticLoadBalancer extends AbstractLoadBalancerSupport<AWSCloud> {
                     logger.warn("Unable to parse time: " + e.getMessage());
                 }
             }
+            else if( name.equalsIgnoreCase("vpcId") ) {
+                vlanId = attr.getFirstChild().getNodeValue().trim();
+            }
             else if( name.equals("healthcheck") ) {
                 withHealthCheck = true;
             }
@@ -1659,6 +1663,9 @@ public class ElasticLoadBalancer extends AbstractLoadBalancerSupport<AWSCloud> {
         }
         if( withHealthCheck ) {
             lb.setProviderLBHealthCheckId(lbId);
+        }
+        if( vlanId != null ) {
+            lb.forVlan(vlanId);
         }
         return lb;
     }


### PR DESCRIPTION
In order to populate the vlan Id we need to pull the vpcId value from the LoadBalancer Response